### PR TITLE
fix 'full' and 'iso' options + add match documentation

### DIFF
--- a/src/w/wbopendata.ado
+++ b/src/w/wbopendata.ado
@@ -27,8 +27,6 @@ version 9.0
 						 CHECK						///
 						 NOPRESERVE					///
 						 PRESERVEOUT				///
-						 FULL						///
-						 ISO						///
 						 COUNTRYMETADATA			///
 						 ALL						///
 						 BREAKNOMETADATA			///

--- a/src/w/wbopendata.sthlp
+++ b/src/w/wbopendata.sthlp
@@ -39,7 +39,7 @@
 {synopt :{opt update query}} query the current vintage of indicators and country metadata available.{p_end}
 {synopt :{opt update check}} checks the availability of new indicators and country metadata available for download.{p_end}
 {synopt :{opt update all}} refreshes the indicators and country metadata information.{p_end}
-{synopt :{opt match(varname)}} mergue {help wbopendata##attributes:country attributes} using WDI countrycodes.{p_end}
+{synopt :{opt match(varname)}} merge {help wbopendata##attributes:country attributes} into an existing dataset containing WDI (3 digit) countrycodes. Cannot be used with the data download options.{p_end}
 {synopt :{opt projection}} World Bank {help wbopendata_sourceid_indicators40##sourceid_40:population estimates and projections} (HPP) .{p_end}
 {synopt :{opt metadataoffline}} download all indicator metadata informaiton and generates 71 sthlp files in your local machine.{p_end}
 {synoptline}
@@ -464,6 +464,14 @@ at the World Bank Data website to identify which format is supported.{p_end}
                size(*.7))
 
 {txt}      ({stata "wbopendata_examples example04":click to run})
+
+{cmd}
+.     sysuse world-d, clear
+.     wbopendata, match(countrycode) 
+.     keep countrycode countryname adminregion incomelevel area perimeter 
+.     list in 1/5
+
+{txt}      ({stata "wbopendata_examples example05":click to run})
 
 {marker disclaimer}{...}
 {title:Disclaimer}

--- a/src/w/wbopendata_examples.ado
+++ b/src/w/wbopendata_examples.ado
@@ -120,3 +120,16 @@ program example04
 			note("Source: World Development Indicators (latest available year as off `time') using Azevedo, J.P. (2011) wbopendata: Stata" "module to access World Bank databases, Statistical Software Components S457234 Boston College Department of Economics.", size(*.7)) 
 			
 end
+
+*  ----------------------------------------------------------------------------
+*  5. match option
+*  ----------------------------------------------------------------------------
+
+capture program drop example05
+program define example05
+    sysuse world-d, clear
+    wbopendata, match(countrycode) 
+    keep countrycode countryname adminregion incomelevel area perimeter 
+    list in 1/5
+
+end


### PR DESCRIPTION
The 'full' and 'iso' options were each listed twice under the syntax command, which caused 'full' to fail, at least for me. Remove the duplicate listings.

I didn't test the effect of deleting the duplicate 'ISO' line. 