### PR TITLE
fix 'full' and 'iso' options

### DIFF
--- a/src/w/wbopendata.ado
+++ b/src/w/wbopendata.ado
@@ -27,8 +27,6 @@ version 9.0
 						 CHECK						///
 						 NOPRESERVE					///
 						 PRESERVEOUT				///
-						 FULL						///
-						 ISO						///
 						 COUNTRYMETADATA			///
 						 ALL						///
 						 BREAKNOMETADATA			///


### PR DESCRIPTION
The 'full' and 'iso' options were each listed twice under the syntax command, which caused them to fail (sometimes?). Remove the duplicate listings.