### PR TITLE
country metadata fixes

### DIFF
--- a/src/_/_countrymetadata.ado
+++ b/src/_/_countrymetadata.ado
@@ -53,27 +53,39 @@ program define _countrymetadata , rclass
 		local tmpadminlist " adminregion adminregion_iso2 adminregionname "
 		local tmpincomelist " incomelevel incomelevel_iso2 incomelevelname "
 		local tmplendinglist " lendingtype lendingtype_iso2 lendingtypename "
-		local tmpcapitalist " capital latitude longitude "
+		local tmpcapitallist " capital latitude longitude "
 
 	******************************************************
 	* asign list variable values if options are selected			
 		if ("`iso'" == "iso") {
-			local isolist " `tmpisolist' "
+			foreach word in `tmpisolist' {
+				local `word' "`word'"
+			}
 		}
 		if ("`regions'" == "regions") {
-			local regionlist " `tmpregionlist' "
+			foreach word in  `tmpregionlist'  {
+				local `word' "`word'"
+			}
 		}
 		if ("`adminr'" == "adminr") {
-			local adminlist " `tmpadminlist' "
+			foreach word in  `tmpadminlist'  {
+				local `word' "`word'"
+			}
 		}
 		if ("`income'" == "income") {
-			local incomelist " `tmpincomelist' "
+			foreach word in  `tmpincomelist' {
+				local `word' "`word'"
+			}
 		}
 		if ("`lending'" == "lending") {
-			local lendinglist " `tmplendinglist' "
+			foreach word in  `tmplendinglist'  {
+				local `word' "`word'"
+			}
 		}
 		if ("`capital'" == "capital") {
-			local capitalist " `tmpcapitallist' "
+			foreach word in `tmpcapitallist' {
+				local `word' "`word'"
+			}
 		}	
 		if ("`full'" == "full") {
 			local full	" countrycode_iso2  countryname  `tmpregionlist' `tmpadminlist' `tmpincomelist' `tmplendinglist' `tmpcapitalist' "

--- a/src/w/wbopendata.ado
+++ b/src/w/wbopendata.ado
@@ -27,8 +27,6 @@ version 9.0
 						 CHECK						///
 						 NOPRESERVE					///
 						 PRESERVEOUT				///
-						 FULL						///
-						 ISO						///
 						 COUNTRYMETADATA			///
 						 ALL						///
 						 BREAKNOMETADATA			///

--- a/src/w/wbopendata.sthlp
+++ b/src/w/wbopendata.sthlp
@@ -39,7 +39,7 @@
 {synopt :{opt update query}} query the current vintage of indicators and country metadata available.{p_end}
 {synopt :{opt update check}} checks the availability of new indicators and country metadata available for download.{p_end}
 {synopt :{opt update all}} refreshes the indicators and country metadata information.{p_end}
-{synopt :{opt match(varname)}} mergue {help wbopendata##attributes:country attributes} using WDI countrycodes.{p_end}
+{synopt :{opt match(varname)}} merge {help wbopendata##attributes:country attributes} into an existing dataset containing WDI (3 digit) countrycodes. Cannot be used with the data download options.{p_end}
 {synopt :{opt projection}} World Bank {help wbopendata_sourceid_indicators40##sourceid_40:population estimates and projections} (HPP) .{p_end}
 {synopt :{opt metadataoffline}} download all indicator metadata informaiton and generates 71 sthlp files in your local machine.{p_end}
 {synoptline}
@@ -464,6 +464,14 @@ at the World Bank Data website to identify which format is supported.{p_end}
                size(*.7))
 
 {txt}      ({stata "wbopendata_examples example04":click to run})
+
+{cmd}
+.     sysuse world-d, clear
+.     wbopendata, match(countrycode) 
+.     keep countrycode countryname adminregion incomelevel area perimeter 
+.     list in 1/5
+
+{txt}      ({stata "wbopendata_examples example05":click to run})
 
 {marker disclaimer}{...}
 {title:Disclaimer}

--- a/src/w/wbopendata_examples.ado
+++ b/src/w/wbopendata_examples.ado
@@ -120,3 +120,16 @@ program example04
 			note("Source: World Development Indicators (latest available year as off `time') using Azevedo, J.P. (2011) wbopendata: Stata" "module to access World Bank databases, Statistical Software Components S457234 Boston College Department of Economics.", size(*.7)) 
 			
 end
+
+*  ----------------------------------------------------------------------------
+*  5. match option
+*  ----------------------------------------------------------------------------
+
+capture program drop example05
+program define example05
+    sysuse world-d, clear
+    wbopendata, match(countrycode) 
+    keep countrycode countryname adminregion incomelevel area perimeter 
+    list in 1/5
+
+end


### PR DESCRIPTION
Several fixes related to country metadata:
1. Fixing the 'full' and 'iso' options
2. adding some documentation on the match option (together with (1), possibly resolves #34 ) 
3. fixing a bug in the suboptions when _countrymetadata.ado is called (possibly resolves #35)