### PR TITLE
fix(v18.6.1): file handle safety, help date, pkg version alignment

### DIFF
--- a/src/_/__wbod_sync_preview.ado
+++ b/src/_/__wbod_sync_preview.ado
@@ -1,6 +1,7 @@
 *******************************************************************************
-*! __wbod_sync_preview v1.4.0  21Apr2026
+*! __wbod_sync_preview v1.4.1  22Apr2026
 *! Display metadata status diagnostic before sync
+*! v1.4.1: Ensure file handle closed on error in capture block
 *! v1.4.0: Add installed version, cache location, inline hyperlinks, clickable detail rows
 *! v1.2.0: Added country metadata count display
 *! v1.1.0: Added detail option for per-source/topic breakdown
@@ -24,16 +25,18 @@ program define __wbod_sync_preview, rclass
     local _wbf : subinstr local _wbf "\" "/" , all
     if fileexists("`_wbf'") {
         tempname _fh
-        capture {
-            file open `_fh' using "`_wbf'", read text
-            forvalues _ln = 1/5 {
-                file read `_fh' _wbline
-                if regexm("`_wbline'", "v ([0-9]+\.[0-9]+\.[0-9]+)") {
-                    local pkg_ver = regexs(1)
-                    continue, break
+        capture file open `_fh' using "`_wbf'", read text
+        if _rc == 0 {
+            capture {
+                forvalues _ln = 1/5 {
+                    file read `_fh' _wbline
+                    if regexm("`_wbline'", "v ([0-9]+\.[0-9]+\.[0-9]+)") {
+                        local pkg_ver = regexs(1)
+                        continue, break
+                    }
                 }
             }
-            file close `_fh'
+            capture file close `_fh'
         }
     }
 

--- a/src/w/wbopendata.sthlp
+++ b/src/w/wbopendata.sthlp
@@ -1,6 +1,6 @@
 {smcl}
 {hline}
-{* 21Apr2026  }{...}
+{* 22Apr2026  }{...}
 {cmd:help wbopendata}{right:dialog:  {bf:{dialog wbopendata}}}
 {right:Indicator List:  {bf:{help wbopendata_sourceid##indicators:Indicators List}}}
 {right:What's New:  {bf:{help wbopendata_whatsnew:What's New}}}

--- a/src/wbopendata.pkg
+++ b/src/wbopendata.pkg
@@ -1,4 +1,4 @@
-v 18.6.0
+v 18.6.1
 d 'WBOPENDATA': module to access World Bank databases
 d 
 d wbopendata allows Stata users to download over 20,000 indicators 
@@ -28,6 +28,7 @@ d Requires: Stata version 14
 d 
 d Distribution-Date: 20260422
 d NEW in v18.6: sync replace now shows a diff of added/removed indicators.
+d NEW in v18.6.1: leading-zero source ID fix in search display; file handle safety.
 d License: MIT
 d 
 d Author: João Pedro Azevedo


### PR DESCRIPTION
## Summary

Syncs three polish fixes from wbopendata-dev (pushed after v18.6.1 tag), addressing Copilot review comments on PR #86:

- **File handle safety** (`__wbod_sync_preview` v1.4.1, commit `a3fbbdb`): `capture file close` now runs unconditionally — `file open` separated from read loop so the handle cannot be leaked on a read error.
- **Help date** (`wbopendata.sthlp`, commit `f22817f`): header corrected from `21Apr2026` → `22Apr2026`, matching CHANGELOG and Distribution-Date.
- **Package version** (`src/wbopendata.pkg`, commit `5b978d6`): bumped to `v18.6.1` to align with the tagged release.

Fixes raised on: https://github.com/jpazvd/wbopendata/pull/86

**Source:** jpazvd/wbopendata-dev @ `5b978d6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)